### PR TITLE
Improve project commands

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setuptools.setup(
     python_requires='>=3.6',
     install_requires=[
       'click>=8.0',
-      'coloredlogs>=14.0'
+      'giturlparse>=0.10.0',
+      'requests>=2.25.1',
     ]
 )


### PR DESCRIPTION
- Migrate form GitPython to simply using os.system() as the user
  experience is consistent with other systems that use git, is easier to
  understand, and is less complex
- Remove `project init`
- Install libcore, libarmcortex, liblpc40xx, libstm32f10x as
  starter libraries for initial development for `project start`
- `project install` can now:
  - Install libraries from outside of the project root using the
    --project_directory flag (same with `project remove` as well)
  - Install libraries outside of the SJSU-Dev2 org
  - Determine if a library has a source code directory (directory with
    the same name as the repo) and and link it rather than always attempting
    ot make a link and generating a broken one.
- `project remove` can now remove libraries
- `build` no longer has name conflicts as it stores generated files
   in the build directory relative path to the files path within the
   project.

Also:

- Remove dependencies except for click and GitPython
- Add `requests` library to setup.py which is needed